### PR TITLE
fix: prevent DOM upgrade when registering a component

### DIFF
--- a/src/js/component-handler.js
+++ b/src/js/component-handler.js
@@ -149,8 +149,6 @@ function registerInternal(config) {
 	if (!found) {
 		registeredComponents_.push(newConfig);
 	}
-
-	upgradeDomInternal(config.classAsString, config.cssClass);
 }
 
 

--- a/test/component-handler.test.js
+++ b/test/component-handler.test.js
@@ -183,27 +183,4 @@ describe('componentHandler', () => {
 
 	});
 
-	describe('.register(config)', () => {
-
-		it('should upgrade the existing DOM', () => {
-			function ComponentTestRegister() {}
-
-			const config = {
-				constructor: ComponentTestRegister,
-				classAsString: 'ComponentTestRegister',
-				cssClass: 'component-test-register'
-			};
-
-			const el = document.createElement('div');
-
-			el.classList.add(config.cssClass);
-			document.body.appendChild(el);
-
-			componentHandler.register(config);
-
-			expect(el.getAttribute('data-upgraded')).to.be(config.classAsString);
-		});
-
-	});
-
 });


### PR DESCRIPTION
The Origami [spec](https://origami.pearsoned.com/docs/syntax/js/#initialization) states that components must do as little as possible on parse. This change removes automatic DOM upgrade when the component class is registered (i.e, when calling `componentHandler.register()`).

This will be released as a bug fix—I don't anticipate any conflicts, as it is only being used at present by the components that we own, and none of the component implementations make any assumption about upgrading on register.

Reviewer: @dstack 